### PR TITLE
feat: hds > 메뉴바 추가

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,16 @@ const withVanillaExtract = createVanillaExtractPlugin();
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/packages/hds/src/components/Item/ItemHorizontalCard/ItemHorizontalCard.css.ts
+++ b/packages/hds/src/components/Item/ItemHorizontalCard/ItemHorizontalCard.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css';
+
+export const rootCss = style({
+  display: 'flex',
+  flexGrow: 1,
+  flexShrink: 1,
+  padding: '0 20px',
+  gap: 20,
+  alignItems: 'center',
+});
+
+export const bodyCss = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+});
+
+export const titleWrapperCss = style({
+  display: 'inline-flex',
+  flexDirection: 'column',
+  gap: 2,
+});

--- a/packages/hds/src/components/Item/ItemHorizontalCard/ItemHorizontalCard.stories.tsx
+++ b/packages/hds/src/components/Item/ItemHorizontalCard/ItemHorizontalCard.stories.tsx
@@ -1,0 +1,28 @@
+import ItemHorizontalCard from '@/components/Item/ItemHorizontalCard/ItemHorizontalCard';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Item/Horizontal/ItemHorizontalCard',
+  component: ItemHorizontalCard,
+  parameters: {
+    layout: 'centered',
+    controls: { include: ['href', 'src', 'title', 'subTitle', 'content'] },
+  },
+  tags: ['autodocs'],
+  args: {
+    href: '/',
+    src: 'https://picsum.photos/400/400',
+    title: '제주감귤에이드',
+    subTitle: 'Berry Orange Ade',
+    content: '4,200원',
+  },
+  argTypes: {},
+} satisfies Meta<typeof ItemHorizontalCard>;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export default meta;

--- a/packages/hds/src/components/Item/ItemHorizontalCard/ItemHorizontalCard.tsx
+++ b/packages/hds/src/components/Item/ItemHorizontalCard/ItemHorizontalCard.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { clsx } from 'clsx';
+import { ItemThumbnail } from '@/components/Item';
+import Link from '@/components/Link';
+import Typo from '@/components/Typo';
+import * as styles from './ItemHorizontalCard.css';
+
+export interface ItemHorizontalCardProps extends React.ComponentPropsWithoutRef<typeof Link> {
+  /** 썸네일 이미지 url */
+  src: string;
+  /** 제목*/
+  title?: string;
+  /** 부제목 */
+  subTitle?: string;
+  /** 내용 */
+  content?: string;
+}
+
+/** 가로형 상품 카드 */
+const ItemHorizontalCard = React.forwardRef<HTMLAnchorElement, ItemHorizontalCardProps>(
+  ({ src, title, subTitle, content, className, ...rest }, ref) => {
+    return (
+      <Link ref={ref} className={clsx(styles.rootCss, className)} {...rest}>
+        <ItemThumbnail src={src} alt={title || ''} />
+        <div className={styles.bodyCss}>
+          <div className={styles.titleWrapperCss}>
+            <Typo variant="text_regular" size={18} color="text_01" as="strong">
+              {title}
+            </Typo>
+            <Typo variant="small_regular" size={14} color="text_02" as="p">
+              {subTitle}
+            </Typo>
+          </div>
+          <Typo variant="text_bold" size={18} color="text_01" as="p">
+            {content}
+          </Typo>
+        </div>
+      </Link>
+    );
+  }
+);
+
+ItemHorizontalCard.displayName = 'ItemHorizontalCard';
+
+export default ItemHorizontalCard;

--- a/packages/hds/src/components/Item/ItemHorizontalCard/index.ts
+++ b/packages/hds/src/components/Item/ItemHorizontalCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ItemHorizontalCard';

--- a/packages/hds/src/components/Item/index.ts
+++ b/packages/hds/src/components/Item/index.ts
@@ -1,3 +1,4 @@
 export { default as ItemThumbnail } from './Item.thumbnail';
 export { default as ItemVerticalCard } from './ItemVerticalCard';
 export { default as ItemVerticalGroup } from './ItemVerticalGroup';
+export { default as ItemHorizontalCard } from './ItemHorizontalCard';

--- a/packages/hds/src/components/Tabs/Tab.css.ts
+++ b/packages/hds/src/components/Tabs/Tab.css.ts
@@ -1,0 +1,40 @@
+import { RecipeVariants, recipe } from '@vanilla-extract/recipes';
+import globalVars from '@/styles/globalVars.css';
+
+export const tabCss = recipe({
+  base: {
+    position: 'relative',
+    minWidth: '60px',
+    paddingBottom: '20px',
+    flexShrink: 0,
+    flexGrow: 0,
+    textAlign: 'center',
+    cursor: 'pointer',
+    transition: 'color 400ms ease-in-out',
+    listStyle: 'none',
+    display: 'inline-block',
+  },
+  variants: {
+    isActive: {
+      true: {
+        '::before': {
+          content: '',
+          minWidth: '60px',
+          width: '100%',
+          height: '4px',
+          backgroundColor: globalVars.color.text_01,
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          borderRadius: '8px',
+        },
+      },
+      false: {},
+    },
+  },
+  defaultVariants: {
+    isActive: false,
+  },
+});
+
+export type TabVariants = RecipeVariants<typeof tabCss>;

--- a/packages/hds/src/components/Tabs/Tab.stories.tsx
+++ b/packages/hds/src/components/Tabs/Tab.stories.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import Tab from '@/components/Tabs/Tab';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'General/Tabs/Tab',
+  component: Tab,
+  parameters: {
+    layout: 'padded',
+    controls: { include: ['href', 'children', 'isActive'] }, // 콘트롤 패널 필터링
+  },
+  tags: ['autodocs'],
+  args: {
+    children: 'COFFEE',
+    href: '/',
+    isActive: false,
+  },
+  argTypes: {},
+} satisfies Meta<typeof Tab>;
+
+type Story = StoryObj<typeof meta>;
+
+const Template: Story = {
+  args: {},
+  render: args => {
+    const [isActive, setIsActive] = useState(false);
+
+    return (
+      <Tab
+        {...args}
+        isActive={isActive}
+        onClick={() => {
+          setIsActive(prev => !prev);
+        }}
+      />
+    );
+  },
+};
+
+export const Default: Story = {
+  ...Template,
+};
+
+export const Active: Story = {
+  args: { isActive: true },
+};
+
+export const MinWidth: Story = {
+  ...Template,
+  args: {
+    children: '짧음',
+  },
+};
+
+export const LongText: Story = {
+  ...Template,
+  args: {
+    children: 'BANACCINO & SMOOTHIE',
+  },
+};
+
+export default meta;

--- a/packages/hds/src/components/Tabs/Tab.tsx
+++ b/packages/hds/src/components/Tabs/Tab.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from 'react';
+import Link from '@/components/Link';
+import * as styles from '@/components/Tabs/Tab.css';
+import Typo from '@/components/Typo';
+import type { TabVariants } from '@/components/Tabs/Tab.css';
+
+interface TabProps extends React.ComponentPropsWithoutRef<typeof Link> {
+  /** 활성화 여부 */
+  isActive?: NonNullable<TabVariants>['isActive'];
+  /** 탭의 레이블 */
+  children: string;
+  /** 탭의 value */
+  value: string;
+}
+
+/**
+ * 메뉴 바에 사용되는 `Tab`
+ * `Tabs` 와 함께 사용
+ *
+ * 최소 너비 60px
+ * */
+const Tab = forwardRef<HTMLAnchorElement, TabProps>(
+  ({ isActive = false, children, ...rest }, ref) => {
+    return (
+      <Link ref={ref} scale="sm" {...rest}>
+        <Typo
+          className={styles.tabCss({ isActive })}
+          variant={isActive ? 'text_bold' : 'text_regular'}
+          color={isActive ? 'text_01' : 'text_02'}
+        >
+          {children}
+        </Typo>
+      </Link>
+    );
+  }
+);
+
+Tab.displayName = 'Tab';
+
+export default Tab;

--- a/packages/hds/src/components/Tabs/Tabs.css.ts
+++ b/packages/hds/src/components/Tabs/Tabs.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+import globalVars from '@/styles/globalVars.css';
+
+export const rootCSS = style({
+  backgroundColor: globalVars.color.background,
+});

--- a/packages/hds/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/hds/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import Tabs from '@/components/Tabs/Tabs';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'General/Tabs',
+  component: Tabs,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  args: {
+    value: 'reco',
+  },
+  argTypes: {},
+} satisfies Meta<typeof Tabs>;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  render: args => {
+    const [value, setValue] = useState(args.value);
+
+    return (
+      <Tabs
+        {...args}
+        value={value}
+        onClick={(_e, newValue) => {
+          setValue(newValue);
+        }}
+      >
+        <Tabs.Tab href="/1" value="reco">
+          추천
+        </Tabs.Tab>
+        <Tabs.Tab href="/2" value="setmenu">
+          SET MENU
+        </Tabs.Tab>
+        <Tabs.Tab href="/3" value="coffee">
+          COFFEE
+        </Tabs.Tab>
+        <Tabs.Tab href="/4" value="decafineCoffee">
+          DECAFEINE COFFEE
+        </Tabs.Tab>
+        <Tabs.Tab href="/5" value="banaccino&smoothie">
+          BANACCINO & SMOOTHIE
+        </Tabs.Tab>
+        <Tabs.Tab href="/6" value="tea&ade">
+          TEA & ADE
+        </Tabs.Tab>
+        <Tabs.Tab href="/7" value="bread&dessert">
+          BREAD&DESSERT
+        </Tabs.Tab>
+      </Tabs>
+    );
+  },
+};
+
+export default meta;

--- a/packages/hds/src/components/Tabs/Tabs.tsx
+++ b/packages/hds/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,51 @@
+import { Children, cloneElement } from 'react';
+import Swiper from '@/components/Swiper';
+import Tab from '@/components/Tabs/Tab';
+import * as styles from './Tabs.css';
+import type { SwiperProps } from 'swiper/react';
+
+interface TabsProps {
+  children?: React.ReactNode;
+  /** value 는 onClick 에 setState를 사용하여 변경 (예시 참고) */
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>, newValue: string) => void;
+  /** 선택된 tab의 value */
+  value: string;
+}
+
+const TabsRoot = ({ value, children, onClick }: TabsProps) => {
+  if (!Array.isArray(children) || typeof children === 'undefined') {
+    return null;
+  }
+
+  return (
+    <Swiper className={styles.rootCSS} {...SWIPER_OPTIONS}>
+      {Children.map(children, child => {
+        return (
+          <Swiper.Slide style={{ width: 'fit-content' }}>
+            {cloneElement(child, {
+              isActive: child.props.value === value,
+              onClick: (e: React.MouseEvent<HTMLAnchorElement>) => {
+                onClick?.(e, child.props.value);
+              },
+            })}
+          </Swiper.Slide>
+        );
+      })}
+    </Swiper>
+  );
+};
+
+/**
+ * 메뉴바
+ * */
+const Tabs = Object.assign(TabsRoot, { Tab: Tab });
+
+const SWIPER_OPTIONS: SwiperProps = {
+  slidesPerView: 'auto',
+  spaceBetween: 20,
+  slidesOffsetBefore: 20,
+  slidesOffsetAfter: 20,
+  loop: false,
+};
+
+export default Tabs;

--- a/packages/hds/src/components/Tabs/index.ts
+++ b/packages/hds/src/components/Tabs/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Tabs';

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,0 +1,13 @@
+import BottomNavUser from '@/components/BottomNav/BottomNavUser';
+import ScrollView from '@hehe/hds//components/ScrollView';
+
+export default function Menu() {
+  return (
+    <>
+      <ScrollView isFullPage topSpacing={0}>
+        메뉴 페이지
+      </ScrollView>
+      <BottomNavUser />
+    </>
+  );
+}

--- a/src/components/BottomNav/BottomNavUser.tsx
+++ b/src/components/BottomNav/BottomNavUser.tsx
@@ -29,7 +29,7 @@ const BottomNavUser = () => {
 const BUTTONS: React.ComponentPropsWithoutRef<typeof BottomNav.Btn>[] = [
   { href: '/', icon: 'icon_home', label: '홈' },
   { href: '/orders', icon: 'icon_member', label: '주문내역' },
-  { href: '/order', icon: 'icon_coffee', label: '주문하기' },
+  { href: '/menu', icon: 'icon_coffee', label: '주문하기' },
   { href: '/setting', icon: 'icon_more', label: '더보기' },
 ];
 


### PR DESCRIPTION
1. hds > 메뉴바 컴포넌트 추가 [76338b0](https://github.com/HeeHeePresso/heehee-fe/pull/30/commits/76338b0b249ac1961df10866a5bdd5c6ff1717f7)
2. hds > 가로형 상품 카드 추가 [aa8495e](https://github.com/HeeHeePresso/heehee-fe/pull/30/commits/aa8495e2ab633ba10eaaa3df3db06512e83a0b3f)
3. fix: remote url 을 가진 이미지 컴포넌트 에러 수정 [2466f72](https://github.com/HeeHeePresso/heehee-fe/pull/30/commits/2466f729bd6cca33fa40f51126ddbafd79b955db)
4. menu 라우팅 추가 [1e20c63](https://github.com/HeeHeePresso/heehee-fe/pull/30/commits/1e20c63b032b86d8072e2e3842650963321493dc)
---
### **메뉴바 컴포넌트** 추가했습니다.

<img width="344" alt="image" src="https://github.com/HeeHeePresso/heehee-fe/assets/23569208/88925871-f925-4e59-b293-ff508a768755">

<img width="1054" alt="image" src="https://github.com/HeeHeePresso/heehee-fe/assets/23569208/383144d7-a5ea-4c33-8152-2029e1ac768e">
<img width="419" alt="image" src="https://github.com/HeeHeePresso/heehee-fe/assets/23569208/f2a7a8cd-e0cc-488c-90e6-ca17879ac1b8">
<img width="448" alt="image" src="https://github.com/HeeHeePresso/heehee-fe/assets/23569208/667049bc-1528-4c63-b70b-1fa349d09821">


- 스토리북 예시 보고 사용하시면 됩니다.

---
### **가로형 상품 카드** 추가했습니다.
<img width="437" alt="image" src="https://github.com/HeeHeePresso/heehee-fe/assets/23569208/7fb7d295-f03e-40e4-b5cd-735793d66a75">
<img width="622" alt="image" src="https://github.com/HeeHeePresso/heehee-fe/assets/23569208/8da108dd-48f5-44d8-80e7-6ca51a4adaa3">



closes #29 